### PR TITLE
feat: add way to start a new test from results

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, useLocation } from 'react-router-dom'
 import { RibbonContainer, RightCornerRibbon } from 'react-ribbons'
 import {
   answerLetter,
@@ -77,6 +77,22 @@ export default function App() {
     })
   }, [])
 
+  const location = useLocation()
+
+  useEffect(() => {
+    const testPaths = ['/', '/test', '/results']
+    const testingURL = testPaths.includes(location.pathname)
+    if (!testingURL || view === 'INFO-start') {
+      // in other pages or on the start of the test, the listener shouldn't be set
+      window.onbeforeunload = null
+    } else if (view.startsWith('TOL')) {
+      // set the listener only if view is during a test, at the recap it is set in ExtendedCorrection.tsx
+      window.onbeforeunload = () => {
+        return 'Sicuro di voler uscire? Il test è ancora in corso'
+      }
+    }
+  }, [view, location])
+
   return (
     <MobileContext.Provider value={{ mobile }}>
       <RibbonContainer>
@@ -131,7 +147,7 @@ export default function App() {
             </Routes>
           </div>
           <Separator />
-          {!view.startsWith('TOL') && <Footer />}
+          {!view.startsWith('TOL') && <Footer view={view} />}
         </div>
       </RibbonContainer>
     </MobileContext.Provider>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { links } from '../utils/constants'
 import { MobileContext } from '../utils/contexts'
 import { StyleSheet, theme } from '../utils/style'
+import { view } from './App'
 
 const styles = StyleSheet.create({
   container: {
@@ -36,7 +37,7 @@ const mobileStyles = StyleSheet.create({
   })
 })
 
-export default function Footer() {
+export default function Footer(props: { view: view }) {
   const { mobile } = useContext(MobileContext)
   const linkStyle = mobile ? mobileStyles.link : styles.link
   return (
@@ -52,7 +53,17 @@ export default function Footer() {
       <Link to="about" style={linkStyle}>
         About
       </Link>
-      <Link to="/" style={linkStyle}>
+      <Link
+        to="/"
+        style={linkStyle}
+        onClick={(e) => {
+          if (props.view === 'INFO-end') {
+            // reload the page if we are in the recap, easier then resetting the state
+            e.preventDefault()
+            location.href = '/'
+          }
+        }}
+      >
         Home
       </Link>
       <Link to="license" style={linkStyle}>

--- a/src/components/InfoView/ExtendedCorrection/ExtendedCorrection.tsx
+++ b/src/components/InfoView/ExtendedCorrection/ExtendedCorrection.tsx
@@ -61,6 +61,10 @@ export default function ExtendedCorrection(props: ExtendedCorrectionProps) {
             .replace(/,/g, '')}`}
           content={() => ref.current}
           trigger={() => <Button label="Salva risultati della simulazione" />}
+          onAfterPrint={() => {
+            // remove the onbeforeunload listener since results are saved
+            window.onbeforeunload = null
+          }}
         />
       </div>
       <div

--- a/src/components/InfoView/InfoEnd.tsx
+++ b/src/components/InfoView/InfoEnd.tsx
@@ -55,6 +55,19 @@ const styles = StyleSheet.create({
   h3: {
     marginBottom: 0,
     paddingInline: '10px'
+  },
+  restartDiv: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'column'
+  },
+  restartTitle: {
+    textAlign: 'center',
+    maxWidth: 500
+  },
+  restartButton: {
+    margin: '12px'
   }
 })
 
@@ -219,6 +232,20 @@ export default function InfoEnd(props: InfoEndProps) {
         Il <b>punteggio</b> complessivo viene arrotondato all'intero più vicino
         (es: il punteggio 59,49 viene arrotondato a 59, il punteggio 59,50 a 60)
       </p>
+      <div style={styles.restartDiv}>
+        <h3 style={styles.restartTitle}>
+          Ricordati di salvare i tuoi risultati prima di iniziare un nuovo test,
+          o andranno persi!
+        </h3>
+        <button
+          style={styles.restartButton}
+          onClick={() => {
+            window.location.reload()
+          }}
+        >
+          Inizia un nuovo test
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/components/InfoView/InfoEnd.tsx
+++ b/src/components/InfoView/InfoEnd.tsx
@@ -69,7 +69,7 @@ const styles = StyleSheet.create({
   },
   restartButton: {
     margin: '12px',
-    marginBottom: '20px'
+    marginBottom: '32px'
   }
 })
 

--- a/src/components/InfoView/InfoEnd.tsx
+++ b/src/components/InfoView/InfoEnd.tsx
@@ -12,6 +12,7 @@ import {
 import { Question, QuestionsData, section } from '../../utils/database'
 import { formatNumber, StyleSheet, theme } from '../../utils/style'
 import { AnswersData } from '../App'
+import Button from '../Util/Button'
 import ExtendedCorrection from './ExtendedCorrection/ExtendedCorrection'
 
 const styles = StyleSheet.create({
@@ -67,7 +68,8 @@ const styles = StyleSheet.create({
     maxWidth: 500
   },
   restartButton: {
-    margin: '12px'
+    margin: '12px',
+    marginBottom: '20px'
   }
 })
 
@@ -237,14 +239,13 @@ export default function InfoEnd(props: InfoEndProps) {
           Ricordati di salvare i tuoi risultati prima di iniziare un nuovo test,
           o andranno persi!
         </h3>
-        <button
+        <Button
+          label="Inizia un nuovo test"
           style={styles.restartButton}
           onClick={() => {
             window.location.reload()
           }}
-        >
-          Inizia un nuovo test
-        </button>
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
I was under the impression that changing the return value for the onbeforeunload event listener would have prompted the user when attempting to close the page, but apparently every major browser dropped support for a custom prompt 🤷 

the test restart is achieved by simply reloading the page, as it's way easier then manually resetting the state, but we could pass down some sort of clearState function if we want to do it in a purer way