### PR TITLE
Fix issue #33

### DIFF
--- a/src/components/QuestionsForm/AnswerForm.tsx
+++ b/src/components/QuestionsForm/AnswerForm.tsx
@@ -10,14 +10,16 @@ const styles = StyleSheet.create({
     fontSize: '11pt'
   },
   label: {
-    display: 'flex'
+    display: 'flex',
+    marginBottom: '2px'
   },
   radioText: {
     display: 'flex',
     fontWeight: 'bold',
     textAlign: 'center',
     verticalAlign: 'middle',
-    paddingInline: '10px'
+    paddingInline: '10px',
+    alignItems: 'flex-start'
   },
   radioSpan: {
     width: '2em',


### PR DESCRIPTION
In order to align radio buttons with the text, the css propriety `align-items` was added.

A little margin-bottom was added to increase readability and click precision, especially on mobile.

Fixes #33 