### PR TITLE
fix: image rendering on non-chromium browsers

### DIFF
--- a/src/components/QuestionsForm/QuestionView.tsx
+++ b/src/components/QuestionsForm/QuestionView.tsx
@@ -19,11 +19,13 @@ const styles = StyleSheet.create({
   attachment: {
     display: 'flex',
     flexDirection: 'column',
+    alignItems: 'flex-start',
     gap: '5px'
   },
   image: {
     maxHeight: '500px',
-    width: 'fit-content'
+    maxWidth: '100%',
+    objectFit: 'contain'
   }
 })
 


### PR DESCRIPTION
Closes #34 
Applied CSS rules to fix image rendering on non-chromium browsers.
This fix has been tested successfully on:

- [X] Firefox 109.0.1 - Windows 11
- [X] Firefox 109.2.0 - Android 9
- [X] Safari - iOS 16
- [ ] Safari >= 15.3 on macOS Monterey
- [ ] Firefox >= 104 on macOS Monterey

Please @EndBug test this on the remaining browsers.

Backward compatibility has been checked successfully on:

- Brave Browser 1.47 (Chromium 109.0.5414.119) - Windows 11
- Microsoft Edge 109.0 (Chromium) - WIndows 11
- Chrome 109.0 - iOS 16


Proof
| firefox 109 a9 | safari ios16  | firefox 109 w11 |
| --------------- | ------------- | ----------------- |
| ![firefox_109_a9](https://user-images.githubusercontent.com/66379281/216780453-17850f6d-b88a-4436-b195-0e9443f9a444.png) | ![safari_ios_16](https://user-images.githubusercontent.com/66379281/216780502-85163cf5-7261-4236-97d7-99100e9abec0.png) | ![firefox_109_w11](https://user-images.githubusercontent.com/66379281/216780573-9f4ff4f1-4dc3-4f81-acc0-5853f2f54698.png) 
