### PR TITLE
Improve end-of-simulation PDF

### DIFF
--- a/src/components/InfoView/ExtendedCorrection/DocumentHeader.tsx
+++ b/src/components/InfoView/ExtendedCorrection/DocumentHeader.tsx
@@ -4,7 +4,6 @@ import { links } from '../../../utils/constants'
 
 const styles = StyleSheet.create({
   div: {
-    height: '70px',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between'

--- a/src/components/InfoView/ExtendedCorrection/ExtendedCorrection.tsx
+++ b/src/components/InfoView/ExtendedCorrection/ExtendedCorrection.tsx
@@ -1,16 +1,20 @@
 import { createRef, forwardRef, ReactNode } from 'react'
 import ReactToPrint from 'react-to-print'
-import { Question, QuestionsData, section } from '../../../utils/database'
+import {
+  Question as IQuestion,
+  QuestionsData,
+  section
+} from '../../../utils/database'
 import { AnswersData } from '../../App'
 import { links, sectionInfo } from '../../../utils/constants'
 import { StyleSheet, theme } from '../../../utils/style'
-import RenderedText from '../../Util/RenderedText'
 import Button from '../../Util/Button'
 import './ExtendedCorrection.css'
 import DocumentHeader from './DocumentHeader'
 import firefoxImg1 from '../../../static/firefox_1.png'
 import firefoxImg2 from '../../../static/firefox_2.png'
 import firefoxImg3 from '../../../static/firefox_3.png'
+import Question from '../../Util/Question'
 
 const styles = StyleSheet.create({
   collapsible: {
@@ -116,93 +120,65 @@ export default function ExtendedCorrection(props: ExtendedCorrectionProps) {
   )
 }
 
+const docStyles = StyleSheet.create({
+  firstPage: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4
+  },
+  li: {
+    marginBottom: 10
+  }
+})
+
 const PrintDocument = forwardRef<HTMLDivElement, ExtendedCorrectionProps>(
   (props: ExtendedCorrectionProps, ref) => {
+    const dateTime = `${new Date().toLocaleDateString()} alle ${new Date().toLocaleTimeString(
+      [],
+      { timeStyle: 'short' }
+    )}`
     const { resultTable, questions, answers } = props
     return (
       <div className="print-only" ref={ref} style={styles.doc}>
-        <div>
-          <div>
-            <DocumentHeader />
-            <p style={styles.centered}>
-              Simulazione del {new Date().toLocaleString()}
-            </p>
-            {resultTable}
-          </div>
-          <br />
-          Hai delle domande sui quesiti e la loro risoluzione? Falle sul{' '}
-          <a
-            href={links.telegramPreparazioneTOL}
-            target="_blank"
-            rel="noreferrer noopener"
-            style={styles.link}
-          >
-            Gruppo preparazione TOL
-          </a>{' '}
-          di PoliNetwork!
-          <br />
-          <br />
-          <br />
-          <span>
+        <div style={docStyles.firstPage}>
+          <DocumentHeader />
+          <p style={styles.centered}>Simulazione del {dateTime}</p>
+          {resultTable}
+          <p>
+            Hai delle domande sui quesiti e la loro risoluzione? Falle sul{' '}
+            <a
+              href={links.telegramPreparazioneTOL}
+              target="_blank"
+              rel="noreferrer noopener"
+              style={styles.link}
+            >
+              Gruppo preparazione TOL
+            </a>{' '}
+            di PoliNetwork!
+          </p>
+          <p>
             Nelle pagine successive troverai, suddivisi per sezione, i quesiti
             che ti sono stati proposti con il relativo esito.
-          </span>
+          </p>
         </div>
-        {(Object.entries(questions) as [section, Question[]][])
+        {(Object.entries(questions) as [section, IQuestion[]][])
           .sort((a, b) => sectionInfo[a[0]].order - sectionInfo[b[0]].order)
           .map(([section, values]) => (
-            <>
-              <div className="page-break" />
-              <div key={section}>
-                <div>
-                  <b>{sectionInfo[section].name}</b>
-                  <ol>
-                    {values.map((question) => {
-                      const letter = answers[section].find(
-                          (a) => a?.id == question.id && a?.sub == question.sub
-                        )?.letter,
-                        result = letter
-                          ? letter == question.correct
-                            ? 'Esatta'
-                            : 'Errata'
-                          : 'Senza risposta'
-
-                      return (
-                        <div key={question.id + (question.sub || 0)}>
-                          <li style={styles.li}>
-                            <RenderedText
-                              text={`
-                            ${question.text} 
-                            `.trim()}
-                            />
-                            &emsp;
-                            <u style={styles.nowrap}>{result}</u>{' '}
-                            <ul style={styles.ul}>
-                              {result == 'Errata' && letter && (
-                                <li>
-                                  <RenderedText
-                                    text={`R. data: ${question.answers[letter]}`}
-                                  />
-                                </li>
-                              )}
-                              {result != 'Esatta' && (
-                                <li>
-                                  <RenderedText
-                                    text={`R. esatta: ${
-                                      question.answers[question.correct]
-                                    }`}
-                                  />
-                                </li>
-                              )}
-                            </ul>
-                          </li>
-                        </div>
-                      )
-                    })}
-                  </ol>
-                </div>
-              </div>
-            </>
+            <div key={section}>
+              <b>{sectionInfo[section].name}</b>
+              <ol>
+                {values.map((q) => {
+                  const letter = answers[section].find(
+                    (a) => a?.id == q.id && a?.sub == q.sub
+                  )?.letter
+                  return (
+                    <li key={q.id + (q.sub || '')} style={docStyles.li}>
+                      <Question q={q} choice={letter} isTest />
+                    </li>
+                  )
+                })}
+              </ol>
+            </div>
           ))}
       </div>
     )

--- a/src/components/QuestionsForm/QuestionView.tsx
+++ b/src/components/QuestionsForm/QuestionView.tsx
@@ -2,6 +2,7 @@ import { getImageURL, Question } from '../../utils/database'
 import { StyleSheet } from '../../utils/style'
 import CollapsibleText from '../Util/CollapsibleText'
 import GeneralPurposeCollapsible from '../Util/GeneralPurposeCollapsible'
+import QuestionAttachments from '../Util/QuestionAttachments'
 import RenderedText from '../Util/RenderedText'
 
 const styles = StyleSheet.create({
@@ -49,20 +50,7 @@ export default function QuestionView({ question }: QuestionViewProps) {
       )}
       <div style={styles.container}>
         <RenderedText text={question.text}></RenderedText>
-
-        {question.attachments?.length && (
-          <GeneralPurposeCollapsible
-            label="mostra/nascondi immagini"
-            contentStyle={styles.collapsible}
-          >
-            {question.attachments.map((fileName, index) => (
-              <span key={index + 1} style={styles.attachment}>
-                <p style={styles.container}>Immagine {index + 1}:</p>
-                <img src={getImageURL(fileName)} style={styles.image} />
-              </span>
-            ))}
-          </GeneralPurposeCollapsible>
-        )}
+        <QuestionAttachments q={question} dbRef="stable" />
       </div>
     </div>
   )

--- a/src/components/QuestionsForm/QuestionView.tsx
+++ b/src/components/QuestionsForm/QuestionView.tsx
@@ -1,7 +1,6 @@
-import { getImageURL, Question } from '../../utils/database'
+import { Question } from '../../utils/database'
 import { StyleSheet } from '../../utils/style'
 import CollapsibleText from '../Util/CollapsibleText'
-import GeneralPurposeCollapsible from '../Util/GeneralPurposeCollapsible'
 import QuestionAttachments from '../Util/QuestionAttachments'
 import RenderedText from '../Util/RenderedText'
 

--- a/src/components/Util/Question.tsx
+++ b/src/components/Util/Question.tsx
@@ -1,5 +1,6 @@
 import { Question as IQuestion } from '../../utils/database'
 import { StyleSheet } from '../../utils/style'
+import QuestionAttachments from './QuestionAttachments'
 import RenderedText from './RenderedText'
 
 const styles = StyleSheet.create({
@@ -18,20 +19,28 @@ const styles = StyleSheet.create({
   }
 })
 
+const TickSign = () => <>&#10003;</>
+const CrossSign = () => <>&#10007;</>
+
 interface Props {
   q: IQuestion
   isDebug?: boolean
   choice?: string
   isTest?: boolean
+  showAttachments?: boolean
+  dbRef?: 'stable' | 'main'
 }
 
 export default function Question({
   q,
   isDebug = false,
   choice = '',
-  isTest = false
+  isTest = false,
+  showAttachments = false,
+  dbRef = 'stable'
 }: Props) {
-  const id = q.sub ? `[${q.id}-${q.sub}] ` : `[${q.id}] `
+  const id = q.id && (q.sub ? `[${q.id}-${q.sub}] ` : `[${q.id}] `)
+  const valid = q.validated !== undefined && `Valid: ${String(q.validated)}`
   let result = 'Senza risposta'
   if (choice.length === 1) {
     result = choice === q.correct ? 'Corretta' : 'Errata'
@@ -44,20 +53,17 @@ export default function Question({
         <RenderedText text={q.text} />
         {isTest && <span style={styles.result}>{result}</span>}
       </p>
+      {showAttachments && <QuestionAttachments q={q} dbRef={dbRef} />}
 
-      {isDebug && <p>Valid: {String(q.validated)}</p>}
+      {isDebug && <p>{valid}</p>}
       {Object.entries(q.answers).map(([letter, text]) => {
         const isCorrect = q.correct === letter
-        const visibility = isCorrect ? 'visible' : 'hidden'
+        const visibility = isCorrect || choice === letter ? 'visible' : 'hidden'
         return (
-          <p
-            key={letter}
-            style={{
-              ...styles.option,
-              fontWeight: letter === choice ? 'bold' : 'normal'
-            }}
-          >
-            <span style={{ visibility }}>→</span>
+          <p key={letter} style={styles.option}>
+            <span style={{ visibility }}>
+              {isCorrect ? <TickSign /> : <CrossSign />}
+            </span>
             <span>{letter.toUpperCase()}. </span>
             <RenderedText text={text} />
           </p>

--- a/src/components/Util/Question.tsx
+++ b/src/components/Util/Question.tsx
@@ -1,0 +1,68 @@
+import { Question as IQuestion } from '../../utils/database'
+import { StyleSheet } from '../../utils/style'
+import RenderedText from './RenderedText'
+
+const styles = StyleSheet.create({
+  question: {
+    padding: 1
+  },
+  option: {
+    display: 'flex',
+    gap: 4,
+    margin: 4
+  },
+  result: {
+    textDecoration: 'underline',
+    paddingTop: 4,
+    display: 'block'
+  }
+})
+
+interface Props {
+  q: IQuestion
+  isDebug?: boolean
+  choice?: string
+  isTest?: boolean
+}
+
+export default function Question({
+  q,
+  isDebug = false,
+  choice = '',
+  isTest = false
+}: Props) {
+  const id = q.sub ? `[${q.id}-${q.sub}] ` : `[${q.id}] `
+  let result = 'Senza risposta'
+  if (choice.length === 1) {
+    result = choice === q.correct ? 'Corretta' : 'Errata'
+  }
+
+  return (
+    <div style={styles.question}>
+      <p style={{ margin: 4 }}>
+        {isDebug && <span>{id}</span>}
+        <RenderedText text={q.text} />
+        {isTest && <span style={styles.result}>{result}</span>}
+      </p>
+
+      {isDebug && <p>Valid: {String(q.validated)}</p>}
+      {Object.entries(q.answers).map(([letter, text]) => {
+        const isCorrect = q.correct === letter
+        const visibility = isCorrect ? 'visible' : 'hidden'
+        return (
+          <p
+            key={letter}
+            style={{
+              ...styles.option,
+              fontWeight: letter === choice ? 'bold' : 'normal'
+            }}
+          >
+            <span style={{ visibility }}>→</span>
+            <span>{letter.toUpperCase()}. </span>
+            <RenderedText text={text} />
+          </p>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/Util/QuestionAttachments.tsx
+++ b/src/components/Util/QuestionAttachments.tsx
@@ -1,0 +1,53 @@
+import { getImageURL, Question } from '../../utils/database'
+import { StyleSheet } from '../../utils/style'
+import GeneralPurposeCollapsible from './GeneralPurposeCollapsible'
+
+const styles = StyleSheet.create({
+  container: {
+    marginBlock: 0,
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  collapsible: {
+    padding: '10px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '15px'
+  },
+  attachment: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    gap: '5px'
+  },
+  image: {
+    maxHeight: '500px',
+    maxWidth: '100%',
+    objectFit: 'contain'
+  }
+})
+
+interface Props {
+  q: Question
+  dbRef: 'stable' | 'main'
+}
+
+export default function QuestionAttachments({ q, dbRef }: Props) {
+  return (
+    <>
+      {q.attachments?.length && (
+        <GeneralPurposeCollapsible
+          label="mostra/nascondi immagini"
+          startOpen={false}
+        >
+          {q.attachments.map((fileName, index) => (
+            <span key={index + 1} style={styles.attachment}>
+              <p style={styles.container}>Immagine {index + 1}:</p>
+              <img src={getImageURL(fileName, dbRef)} style={styles.image} />
+            </span>
+          ))}
+        </GeneralPurposeCollapsible>
+      )}
+    </>
+  )
+}

--- a/src/components/pages/DBPreview.tsx
+++ b/src/components/pages/DBPreview.tsx
@@ -34,7 +34,7 @@ export default function DBPreview({ db }: DBPreviewProps) {
                 .filter((q) => q.text || key == 'com')
                 .map((q) => (
                   <li key={key + q.id + (q.sub || '')}>
-                    <Question q={q} isDebug={true} />
+                    <Question q={q} isDebug={true} showAttachments />
                   </li>
                 ))}
             </ul>

--- a/src/components/pages/DBPreview.tsx
+++ b/src/components/pages/DBPreview.tsx
@@ -1,9 +1,15 @@
 import { sectionInfo } from '../../utils/constants'
-import { section, Database, Question } from '../../utils/database'
-import { baseStyle } from '../../utils/style'
+import { section, Database, Question as IQuestion } from '../../utils/database'
+import { baseStyle, StyleSheet } from '../../utils/style'
 import GeneralPurposeCollapsible from '../Util/GeneralPurposeCollapsible'
+import Question from '../Util/Question'
 
-import RenderedText from '../Util/RenderedText'
+const styles = StyleSheet.create({
+  ul: {
+    margin: 10,
+    paddingLeft: 16
+  }
+})
 
 interface DBPreviewProps {
   db?: Database
@@ -15,7 +21,7 @@ export default function DBPreview({ db }: DBPreviewProps) {
       {(
         Object.entries(db).filter(([key]) => key != 'meta') as [
           section,
-          Question[]
+          IQuestion[]
         ][]
       ).map(([key, questions]) => (
         <div key={key} style={baseStyle}>
@@ -23,30 +29,12 @@ export default function DBPreview({ db }: DBPreviewProps) {
             label={sectionInfo[key].name}
             startOpen={false}
           >
-            <ul>
+            <ul style={styles.ul}>
               {questions
                 .filter((q) => q.text || key == 'com')
                 .map((q) => (
                   <li key={key + q.id + (q.sub || '')}>
-                    [{q.id}
-                    {q.sub ? '-' + q.sub : ''}] <RenderedText text={q.text} />
-                    <br />
-                    <p>Valid: {q.validated + ''}</p>
-                    {Object.entries(q.answers).map(([letter, text]) => (
-                      <p key={letter}>
-                        <span
-                          style={{
-                            visibility:
-                              letter == q.correct ? 'visible' : 'hidden'
-                          }}
-                        >
-                          →{' '}
-                        </span>
-                        <RenderedText text={text} />
-                      </p>
-                    ))}
-                    <br />
-                    <br />
+                    <Question q={q} isDebug={true} />
                   </li>
                 ))}
             </ul>


### PR DESCRIPTION
A new component `Question` was created to display questions in the same way in different pages.
It was used in `dbpreview` route and in the `PrintDocument` component (the one used to print the PDF)

The component has the following props:
- `isDebug` to display question id and validation (used for `dbpreview`)
- `isTest` to include test choice and result (that is "Senza Risposta" || "Corretta" || "Errata" in the results PDF)
- `q` which is the question itself to be displayed
- `choice` meant to be used with `isTest = true` to pass through the "letter" of the user guess

Following the layout of `dbpreview` questions:

- an arrow marks the correct answer
- if the user has made a choice, the answer selected is displayed in bold
- letters are displayed (before they weren't)

As a new implementation, feel free to give your opinions besides the bare code review.

p.s.: there was a blank page (position 2) in the results PDF, which has been removed.

Resolves #58 