### PR TITLE
feat: allow changing db source in dbpreview

### DIFF
--- a/src/components/InfoView/ExtendedCorrection/ExtendedCorrection.tsx
+++ b/src/components/InfoView/ExtendedCorrection/ExtendedCorrection.tsx
@@ -3,7 +3,7 @@ import ReactToPrint from 'react-to-print'
 import {
   Question as IQuestion,
   QuestionsData,
-  section
+  Section
 } from '../../../utils/database'
 import { AnswersData } from '../../App'
 import { links, sectionInfo } from '../../../utils/constants'
@@ -161,7 +161,7 @@ const PrintDocument = forwardRef<HTMLDivElement, ExtendedCorrectionProps>(
             che ti sono stati proposti con il relativo esito.
           </p>
         </div>
-        {(Object.entries(questions) as [section, IQuestion[]][])
+        {(Object.entries(questions) as [Section, IQuestion[]][])
           .sort((a, b) => sectionInfo[a[0]].order - sectionInfo[b[0]].order)
           .map(([section, values]) => (
             <div key={section}>

--- a/src/components/InfoView/InfoEnd.tsx
+++ b/src/components/InfoView/InfoEnd.tsx
@@ -8,7 +8,7 @@ import {
   testPassThreshold,
   testTotalScore
 } from '../../utils/constants'
-import { Question, QuestionsData, section } from '../../utils/database'
+import { Question, QuestionsData, Section } from '../../utils/database'
 import { formatNumber, StyleSheet, theme } from '../../utils/style'
 import { AnswersData } from '../App'
 import Button from '../Util/Button'
@@ -79,7 +79,7 @@ export default function InfoEnd(props: InfoEndProps) {
   const { answers, questions } = props
 
   const correctionGrid = fromEntries(
-    (Object.entries(questions) as [section, Question[]][]).map(
+    (Object.entries(questions) as [Section, Question[]][]).map(
       ([section, secQuestions]) => {
         let correct = 0,
           notGiven = 0,
@@ -122,7 +122,7 @@ export default function InfoEnd(props: InfoEndProps) {
   )
 
   const score = (
-    Object.entries(correctionGrid) as [section, typeof correctionGrid[string]][]
+    Object.entries(correctionGrid) as [Section, typeof correctionGrid[string]][]
   )
     .map(([, correction]) => correction.score.mul(correction.weight))
     .reduce((acc, curr) => acc.add(curr), new Fraction(0))
@@ -157,8 +157,8 @@ export default function InfoEnd(props: InfoEndProps) {
           </tr>
           {(
             Object.entries(correctionGrid) as [
-              section,
-              typeof correctionGrid[section]
+              Section,
+              typeof correctionGrid[Section]
             ][]
           )
             .sort((a, b) => sectionInfo[a[0]].order - sectionInfo[b[0]].order)

--- a/src/components/QuestionsForm/QuestionView.tsx
+++ b/src/components/QuestionsForm/QuestionView.tsx
@@ -1,3 +1,4 @@
+import { DATABASE_REF } from '../../utils/constants'
 import { Question } from '../../utils/database'
 import { StyleSheet } from '../../utils/style'
 import CollapsibleText from '../Util/CollapsibleText'
@@ -49,7 +50,7 @@ export default function QuestionView({ question }: QuestionViewProps) {
       )}
       <div style={styles.container}>
         <RenderedText text={question.text}></RenderedText>
-        <QuestionAttachments q={question} dbRef="stable" />
+        <QuestionAttachments q={question} dbRef={DATABASE_REF.STABLE} />
       </div>
     </div>
   )

--- a/src/components/QuestionsForm/QuestionsForm.tsx
+++ b/src/components/QuestionsForm/QuestionsForm.tsx
@@ -8,7 +8,7 @@ import {
   sectionInfo
 } from '../../utils/constants'
 import { TestContext } from '../../utils/contexts'
-import { section, QuestionsData } from '../../utils/database'
+import { Section, QuestionsData } from '../../utils/database'
 import { StyleSheet } from '../../utils/style'
 import { statePair } from '../../utils/types'
 import { Answer, AnswersData, TimeRecord, view } from '../App'
@@ -27,7 +27,7 @@ const styles = StyleSheet.create({
 interface QuestionsFormProps {
   answersState: statePair<AnswersData>
   questions: QuestionsData
-  sectionState: statePair<section>
+  sectionState: statePair<Section>
   timeRecordState: statePair<TimeRecord>
   viewState: statePair<view>
 }

--- a/src/components/QuestionsForm/RecapBar.tsx
+++ b/src/components/QuestionsForm/RecapBar.tsx
@@ -1,4 +1,4 @@
-import { answerLetter, section, QuestionsData } from '../../utils/database'
+import { AnswerLetter, Section, QuestionsData } from '../../utils/database'
 import { StyleSheet, theme } from '../../utils/style'
 import { statePair } from '../../utils/types'
 import { AnswersData } from '../App'
@@ -44,8 +44,8 @@ const styles = StyleSheet.create({
 interface RecapBarProps {
   active: boolean
   currentQuestionIndexState: statePair<number>
-  sectionAnswers: AnswersData[section]
-  sectionQuestions: QuestionsData[section]
+  sectionAnswers: AnswersData[Section]
+  sectionQuestions: QuestionsData[Section]
 }
 export default function RecapBar(props: RecapBarProps) {
   return (
@@ -80,7 +80,7 @@ export default function RecapBar(props: RecapBarProps) {
 
 interface AnswerCellProps {
   index: number
-  letter: answerLetter | undefined
+  letter: AnswerLetter | undefined
   flagged: boolean
   onClick: () => void
   selected: boolean

--- a/src/components/QuestionsForm/SectionRecap.tsx
+++ b/src/components/QuestionsForm/SectionRecap.tsx
@@ -1,5 +1,5 @@
 import { sectionInfo } from '../../utils/constants'
-import { QuestionsData, section } from '../../utils/database'
+import { QuestionsData, Section } from '../../utils/database'
 import { StyleSheet } from '../../utils/style'
 import { AnswersData } from '../App'
 import Button from '../Util/Button'
@@ -16,9 +16,9 @@ const styles = StyleSheet.create({
 
 interface SectionRecapProps {
   goToNextSection: () => void
-  section: section
-  sectionAnswers: AnswersData[section]
-  sectionQuestions: QuestionsData[section]
+  section: Section
+  sectionAnswers: AnswersData[Section]
+  sectionQuestions: QuestionsData[Section]
   secondsUsed: number
   minutes: number
 }

--- a/src/components/QuestionsForm/TopControls.tsx
+++ b/src/components/QuestionsForm/TopControls.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react'
 import { TimerResult } from 'react-timer-hook'
 import { getSectionName } from '../../utils/constants'
 import { MobileContext } from '../../utils/contexts'
-import { section, QuestionsData } from '../../utils/database'
+import { Section, QuestionsData } from '../../utils/database'
 import { StyleSheet } from '../../utils/style'
 import { AnswersData } from '../App'
 import Button from '../Util/Button'
@@ -37,7 +37,7 @@ interface TopControlsProps {
   active: boolean
   answers: AnswersData
   closeSection: () => void
-  currentSection: section
+  currentSection: Section
   timer: TimerResult
   questions: QuestionsData
 }

--- a/src/components/Util/Question.tsx
+++ b/src/components/Util/Question.tsx
@@ -1,3 +1,4 @@
+import { DATABASE_REF } from '../../utils/constants'
 import { Question as IQuestion } from '../../utils/database'
 import { StyleSheet } from '../../utils/style'
 import QuestionAttachments from './QuestionAttachments'
@@ -28,7 +29,7 @@ interface Props {
   choice?: string
   isTest?: boolean
   showAttachments?: boolean
-  dbRef?: 'stable' | 'main'
+  dbRef?: DATABASE_REF
 }
 
 export default function Question({
@@ -37,7 +38,7 @@ export default function Question({
   choice = '',
   isTest = false,
   showAttachments = false,
-  dbRef = 'stable'
+  dbRef = DATABASE_REF.STABLE
 }: Props) {
   const id = q.id && (q.sub ? `[${q.id}-${q.sub}] ` : `[${q.id}] `)
   const valid = q.validated !== undefined && `Valid: ${String(q.validated)}`

--- a/src/components/Util/QuestionAttachments.tsx
+++ b/src/components/Util/QuestionAttachments.tsx
@@ -1,3 +1,4 @@
+import { DATABASE_REF } from '../../utils/constants'
 import { getImageURL, Question } from '../../utils/database'
 import { StyleSheet } from '../../utils/style'
 import GeneralPurposeCollapsible from './GeneralPurposeCollapsible'
@@ -29,7 +30,7 @@ const styles = StyleSheet.create({
 
 interface Props {
   q: Question
-  dbRef: 'stable' | 'main'
+  dbRef: DATABASE_REF
 }
 
 export default function QuestionAttachments({ q, dbRef }: Props) {

--- a/src/components/Util/Select.tsx
+++ b/src/components/Util/Select.tsx
@@ -17,6 +17,7 @@ interface SelectEntry {
 
 interface ButtonProps {
   defaultValue?: string
+  value?: string
   disabled?: boolean
   entries: SelectEntry[]
   label?: string
@@ -25,16 +26,16 @@ interface ButtonProps {
 }
 
 export default function Select(props: ButtonProps) {
-  const [value, setValue] = useState(props.defaultValue)
+  const [localValue, setLocalValue] = useState(props.defaultValue)
 
   return (
     <label>
       {props.label || ''}
       <select
-        value={value}
+        value={props.value || localValue}
         onChange={(e) => {
           const newValue = e.target.value
-          setValue(newValue)
+          setLocalValue(newValue)
           props.onChange && props.onChange(newValue)
         }}
         style={styles.select}

--- a/src/components/pages/DBPreview.tsx
+++ b/src/components/pages/DBPreview.tsx
@@ -1,8 +1,14 @@
-import { sectionInfo } from '../../utils/constants'
-import { section, Database, Question as IQuestion } from '../../utils/database'
+import { useState } from 'react'
+import { DATABASE_REF, sectionInfo } from '../../utils/constants'
+import {
+  Section,
+  Question as IQuestion,
+  DatabaseStore
+} from '../../utils/database'
 import { baseStyle, StyleSheet } from '../../utils/style'
 import GeneralPurposeCollapsible from '../Util/GeneralPurposeCollapsible'
 import Question from '../Util/Question'
+import Select from '../Util/Select'
 
 const styles = StyleSheet.create({
   ul: {
@@ -12,15 +18,27 @@ const styles = StyleSheet.create({
 })
 
 interface DBPreviewProps {
-  db?: Database
+  dbs?: DatabaseStore
 }
 
-export default function DBPreview({ db }: DBPreviewProps) {
-  return db ? (
+export default function DBPreview({ dbs }: DBPreviewProps) {
+  if (!dbs) return <div style={baseStyle}>Loading...</div>
+  const [db, setDb] = useState(dbs.stable)
+
+  return (
     <div>
+      <Select
+        label="Database"
+        entries={[
+          { value: DATABASE_REF.STABLE, label: 'Production' },
+          { value: DATABASE_REF.MAIN, label: 'Development' }
+        ]}
+        defaultValue={DATABASE_REF.STABLE}
+        onChange={(v) => setDb(dbs[v as DATABASE_REF])}
+      />
       {(
         Object.entries(db).filter(([key]) => key != 'meta') as [
-          section,
+          Section,
           IQuestion[]
         ][]
       ).map(([key, questions]) => (
@@ -42,7 +60,5 @@ export default function DBPreview({ db }: DBPreviewProps) {
         </div>
       ))}
     </div>
-  ) : (
-    <div style={baseStyle}>Loading...</div>
   )
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import { section } from './database'
+import { Section } from './database'
 import Fraction from 'fraction.js'
 
 export const links = {
@@ -28,7 +28,7 @@ interface sectionInfoElement {
   coeff: number | Fraction
 }
 
-export const sectionInfo: Record<section, sectionInfoElement> = {
+export const sectionInfo: Record<Section, sectionInfoElement> = {
   ing: {
     name: 'Inglese',
     order: 1,
@@ -74,14 +74,14 @@ export const correctionWeight = {
   notGiven: 0
 }
 
-export function getSectionName(key: section) {
+export function getSectionName(key: Section) {
   return sectionInfo[key].name
 }
 
-export function getNextSection(currentSection: section): section | undefined {
+export function getNextSection(currentSection: Section): Section | undefined {
   const sortedInfo = Object.entries(sectionInfo).sort(
     (a, b) => a[1].order - b[1].order
-  ) as [section, sectionInfoElement][]
+  ) as [Section, sectionInfoElement][]
   const i = sortedInfo.findIndex((e) => e[0] == currentSection)
   return (sortedInfo[i + 1] || [])[0]
 }
@@ -154,3 +154,8 @@ export const STORAGE = {
   LANG: 'tol_i18n_lng',
   LAST_CHANGE: 'tol_last_change'
 } as const
+
+export enum DATABASE_REF {
+  STABLE = 'stable',
+  MAIN = 'main'
+}

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import fromEntries from 'fromentries'
 import _ from 'underscore'
 import packageJson from '../../package.json'
-import { sectionInfo } from './constants'
+import { DATABASE_REF, sectionInfo } from './constants'
 
 export const sheetDict = {
   quesiti_ING: 'ing',
@@ -10,15 +10,15 @@ export const sheetDict = {
   quesiti_COM: 'com',
   quesiti_FIS: 'fis'
 } as const
-export type section = typeof sheetDict[keyof typeof sheetDict]
+export type Section = typeof sheetDict[keyof typeof sheetDict]
 
-export type answerLetter = 'a' | 'b' | 'c' | 'd' | 'e'
+export type AnswerLetter = 'a' | 'b' | 'c' | 'd' | 'e'
 
 export interface Question {
   id: string
   text: string
-  answers: Record<answerLetter, string>
-  correct: answerLetter
+  answers: Record<AnswerLetter, string>
+  correct: AnswerLetter
   attachments: string[]
   validated: boolean
 
@@ -27,7 +27,7 @@ export interface Question {
   track?: string
 }
 
-export type QuestionsData = Record<section, Question[]>
+export type QuestionsData = Record<Section, Question[]>
 
 export interface Database extends QuestionsData {
   meta: {
@@ -35,7 +35,7 @@ export interface Database extends QuestionsData {
   }
 }
 
-export async function readDatabase(ref = 'stable') {
+export async function readDatabase(ref: DATABASE_REF = DATABASE_REF.STABLE) {
   const db = (
     await axios.get(
       `https://raw.githubusercontent.com/PoliNetworkOrg/TheTOLProjectData/${ref}/database.json`
@@ -53,7 +53,7 @@ export async function readDatabase(ref = 'stable') {
 export function selectRandomQuestions(db: Database): QuestionsData {
   return fromEntries(
     // Manipulate db entries
-    (Object.entries(db) as [section /* or "meta" */, Question[]][])
+    (Object.entries(db) as [Section /* or "meta" */, Question[]][])
       // Select only entries associated with a section <=> exclude "meta"
       .filter(([key]) => (Object.values(sheetDict) as string[]).includes(key))
       .map(([key, questions]) => {
@@ -75,6 +75,11 @@ export function selectRandomQuestions(db: Database): QuestionsData {
   ) as QuestionsData
 }
 
-export function getImageURL(fileName: string, ref = 'stable') {
+export function getImageURL(
+  fileName: string,
+  ref: DATABASE_REF = DATABASE_REF.STABLE
+) {
   return `https://raw.githubusercontent.com/PoliNetworkOrg/TheTOLProjectData/${ref}/img/${fileName}`
 }
+
+export type DatabaseStore = Record<DATABASE_REF, Database>


### PR DESCRIPTION
## Main change

> Referring to other changes below

In `DBPreview.tsx`, added a  `<Select />` to switch between databases (loaded from `App.tsx`), following `QPreview.tsx` changes

Closes #60 

## Other changes
- Renamed type `section` to `Section`
- Renamed type `answerLetter` to `AnswerLetter`
- Defined database references in a enum type `DATABASE_REF` with `MAIN` and `STABLE` options (if refs ever change, they will be changed in a single place)
- Databases (all refs) are loaded in `App.tsx` once, then passed along components, reducing loading times
  - Created `type DatabaseStore = Record<DATABASE_REF, Database>` to collect databases loaded
  - Components can select the db ref via the defined enum `DATABASE_REF`
- `Select` component was updated so that it supports controlled value from parent component's state
- `QPreview.tsx`
  - Uses databases loaded from `App.tsx`
  - HTML structure simplified: `<Select />` entries points to variables that get updated from `useMemo` hook, avoiding useless recomputing on each render
  - Removed empty entries in `<Select />` because entries are always available and the first one is selected by default
  - If a question is selected and changing the database that question is not present anymore, the first question of the current section in the new database is selected

## Notes
Considered this as a feature instead of a fix, because the issue doesn't consist in a bug but a feature miss.