### PR TITLE
feat: revert history and protect Test navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "react-icons": "^4.3.1",
         "react-latex": "^2.0.0",
         "react-ribbons": "github:EndBug/react-ribbons#custom",
-        "react-router-dom": "^6.0.2",
+        "react-router-dom": "^6.10.0",
         "react-scripts": "4.0.3",
         "react-timer-hook": "^3.0.5",
         "react-to-print": "^2.14.0",
@@ -2614,6 +2614,14 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -9570,13 +9578,6 @@
       "version": "1.1.0",
       "license": "MIT"
     },
-    "node_modules/history": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "license": "MIT",
@@ -15987,21 +15988,29 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.0.2",
-      "license": "MIT",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.10.0.tgz",
+      "integrity": "sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==",
       "dependencies": {
-        "history": "^5.1.0"
+        "@remix-run/router": "1.5.0"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.0.2",
-      "license": "MIT",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.10.0.tgz",
+      "integrity": "sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==",
       "dependencies": {
-        "history": "^5.1.0",
-        "react-router": "6.0.2"
+        "@remix-run/router": "1.5.0",
+        "react-router": "6.10.0"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -22540,6 +22549,11 @@
         }
       }
     },
+    "@remix-run/router": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
+      "integrity": "sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg=="
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "requires": {
@@ -27078,12 +27092,6 @@
     "hex-color-regex": {
       "version": "1.1.0"
     },
-    "history": {
-      "version": "5.1.0",
-      "requires": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "requires": {
@@ -31219,16 +31227,20 @@
       "requires": {}
     },
     "react-router": {
-      "version": "6.0.2",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.10.0.tgz",
+      "integrity": "sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==",
       "requires": {
-        "history": "^5.1.0"
+        "@remix-run/router": "1.5.0"
       }
     },
     "react-router-dom": {
-      "version": "6.0.2",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.10.0.tgz",
+      "integrity": "sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==",
       "requires": {
-        "history": "^5.1.0",
-        "react-router": "6.0.2"
+        "@remix-run/router": "1.5.0",
+        "react-router": "6.10.0"
       }
     },
     "react-scripts": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-icons": "^4.3.1",
     "react-latex": "^2.0.0",
     "react-ribbons": "github:EndBug/react-ribbons#custom",
-    "react-router-dom": "^6.0.2",
+    "react-router-dom": "^6.10.0",
     "react-scripts": "4.0.3",
     "react-timer-hook": "^3.0.5",
     "react-to-print": "^2.14.0",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -54,7 +54,7 @@ export default function Footer(props: { view: view }) {
       >
         Source
       </a>
-      <Link to="about" style={linkStyle} replace>
+      <Link to="about" style={linkStyle}>
         About
       </Link>
       <Link
@@ -67,14 +67,13 @@ export default function Footer(props: { view: view }) {
             window.location.reload()
           }
         }}
-        replace
       >
         Home
       </Link>
-      <Link to="license" style={linkStyle} replace>
+      <Link to="license" style={linkStyle}>
         License
       </Link>
-      <Link to="privacy" style={linkStyle} replace>
+      <Link to="privacy" style={linkStyle}>
         Privacy & Cookies
       </Link>
     </div>

--- a/src/components/InfoView/InfoView.tsx
+++ b/src/components/InfoView/InfoView.tsx
@@ -28,7 +28,7 @@ export default function InfoView(props: InfoViewProps) {
     <InfoStart
       startTest={() => {
         setView('TOL-testing')
-        navigate('/test', { replace: true })
+        navigate('/test')
         PanelBear.track('TestStart')
       }}
     />

--- a/src/components/QuestionsForm/QuestionsForm.tsx
+++ b/src/components/QuestionsForm/QuestionsForm.tsx
@@ -202,15 +202,18 @@ export default function QuestionsForm(props: QuestionsFormProps) {
   }
 
   useBlocker(view.startsWith('TOL'))
+  const exit_warn =
+    'Sei sicuro di voler abbandonare il test? I progressi non verranno salvati.'
   const handleExitTest = () => {
-    if (
-      confirm(
-        'Sei sicuro di voler abbandonare il test? I progressi non verranno salvati.'
-      )
-    ) {
+    const confirmExit = confirm(exit_warn)
+    if (confirmExit) {
+      // user confirmed to exit the test
       // set onbeforeunload to null, otherwise the prompt is shown twice
       window.onbeforeunload = null
       location.reload()
+    } else {
+      // if aborted, set back the reload protection
+      window.onbeforeunload = () => exit_warn
     }
   }
 

--- a/src/components/QuestionsForm/QuestionsForm.tsx
+++ b/src/components/QuestionsForm/QuestionsForm.tsx
@@ -1,5 +1,9 @@
 import { useContext, useEffect, useState } from 'react'
-import { useNavigate } from 'react-router'
+import {
+  useNavigate,
+  unstable_useBlocker as useBlocker,
+  Navigate
+} from 'react-router-dom'
 import { useTimer } from 'react-timer-hook'
 import { PanelBear } from '../..'
 import {
@@ -194,7 +198,20 @@ export default function QuestionsForm(props: QuestionsFormProps) {
           minutes={sectionInfo[currentSection].minutes * minutesCoeff}
         />
       )
-    else return <div />
+    else return <Navigate to="/" replace />
+  }
+
+  useBlocker(view.startsWith('TOL'))
+  const handleExitTest = () => {
+    if (
+      confirm(
+        'Sei sicuro di voler abbandonare il test? I progressi non verranno salvati.'
+      )
+    ) {
+      // set onbeforeunload to null, otherwise the prompt is shown twice
+      window.onbeforeunload = null
+      location.reload()
+    }
   }
 
   return (
@@ -202,9 +219,8 @@ export default function QuestionsForm(props: QuestionsFormProps) {
       <TopControls
         active={view == 'TOL-testing'}
         answers={answers}
-        closeSection={() => {
-          closeSection()
-        }}
+        closeSection={closeSection}
+        exitTest={handleExitTest}
         currentSection={currentSection}
         questions={props.questions}
         timer={timer}

--- a/src/components/QuestionsForm/TopControls.tsx
+++ b/src/components/QuestionsForm/TopControls.tsx
@@ -20,6 +20,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: '15px',
     fontSize: '11pt'
+  },
+  exitBtn: {
+    background: '#d81e11',
+    border: '2px solid #d81e11',
+    fontSize: '9.5pt',
+    color: 'white',
+    borderRadius: 2,
+    cursor: 'pointer'
   }
 })
 
@@ -37,6 +45,7 @@ interface TopControlsProps {
   active: boolean
   answers: AnswersData
   closeSection: () => void
+  exitTest: () => void
   currentSection: Section
   timer: TimerResult
   questions: QuestionsData
@@ -65,7 +74,12 @@ export default function TopControls(props: TopControlsProps) {
           </p>
         </div>
         {props.active && (
-          <Button label="Chiudi sezione" onClick={props.closeSection} />
+          <>
+            <Button label="Chiudi sezione" onClick={props.closeSection} />
+            <button style={styles.exitBtn} onClick={props.exitTest}>
+              Abbandona il test
+            </button>
+          </>
         )}
       </div>
       <Timer timer={props.timer} />

--- a/src/components/pages/About.tsx
+++ b/src/components/pages/About.tsx
@@ -40,7 +40,7 @@ export default function About() {
       <p style={styles.p}>
         <Trans i18n={i18n}>about.main</Trans>
       </p>
-      <p style={styles.p}>
+      <div style={styles.p}>
         <b>{t('about.projectTeam')}</b>
         <br />
         <ul>
@@ -124,7 +124,7 @@ export default function About() {
             </div>
           </li>
         </ul>
-      </p>
+      </div>
     </Wrapper>
   )
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { HashRouter } from 'react-router-dom'
 import * as PanelBear from '@panelbear/panelbear-js'
 export * as PanelBear from '@panelbear/panelbear-js'
 
@@ -14,9 +13,7 @@ PanelBear.load('5FyulkL10oK')
 ReactDOM.render(
   <React.StrictMode>
     <I18nextProvider i18n={i18n}>
-      <HashRouter>
-        <App />
-      </HashRouter>
+      <App />
     </I18nextProvider>
   </React.StrictMode>,
   document.getElementById('root')


### PR DESCRIPTION
- Browser history is reverted
- During test phase the user can't go back in browser history (thanks to `useBlocker` hook)
- Added a button to exit the test (with confirm prompt)
- in `App.tsx`, part of the DOM has been moved to a separate function `Layout` because otherwise react-router was complaining about the context.

`react-router-dom` library has been updated to the LTS version (6.10.0) which includes the `unstable_useBlocker` hook, used to prevent navigation in test phase.

> Even if it's marked as unstable, from my tests it seems to be working fine, @EndBug feel free to test it with BrowserStack. Also this is suggested [here](https://github.com/remix-run/react-router/issues/8139)

Closes #26 