### PR TITLE
fix: remove PanelBear

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "the-tol-project",
       "version": "1.1.1",
       "dependencies": {
-        "@panelbear/panelbear-js": "^1.3.2",
         "@types/google-spreadsheet": "^3.1.5",
         "@types/node": "^16.10.3",
         "@types/react": "^17.0.27",
@@ -2559,10 +2558,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@panelbear/panelbear-js": {
-      "version": "1.3.2",
-      "license": "Apache-2.0"
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.4.3",
@@ -22529,9 +22524,6 @@
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
       }
-    },
-    "@panelbear/panelbear-js": {
-      "version": "1.3.2"
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test": "npm run build && npm run lint && npm run exports"
   },
   "dependencies": {
-    "@panelbear/panelbear-js": "^1.3.2",
     "@types/google-spreadsheet": "^3.1.5",
     "@types/node": "^16.10.3",
     "@types/react": "^17.0.27",

--- a/src/components/InfoView/InfoView.tsx
+++ b/src/components/InfoView/InfoView.tsx
@@ -1,5 +1,4 @@
 import { Navigate, useLocation, useNavigate } from 'react-router'
-import { PanelBear } from '../..'
 import { QuestionsData } from '../../utils/database'
 import { statePair } from '../../utils/types'
 import { AnswersData, view } from '../App'
@@ -29,7 +28,8 @@ export default function InfoView(props: InfoViewProps) {
       startTest={() => {
         setView('TOL-testing')
         navigate('/test')
-        PanelBear.track('TestStart')
+        // insert new tracker here
+        // .track('TestStart')
       }}
     />
   ) : view == 'INFO-end' ? (

--- a/src/components/InfoView/InfoView.tsx
+++ b/src/components/InfoView/InfoView.tsx
@@ -28,8 +28,6 @@ export default function InfoView(props: InfoViewProps) {
       startTest={() => {
         setView('TOL-testing')
         navigate('/test')
-        // insert new tracker here
-        // .track('TestStart')
       }}
     />
   ) : view == 'INFO-end' ? (

--- a/src/components/QuestionsForm/QuestionsForm.tsx
+++ b/src/components/QuestionsForm/QuestionsForm.tsx
@@ -187,8 +187,6 @@ export default function QuestionsForm(props: QuestionsFormProps) {
             } else {
               setView('INFO-end')
               navigate('/results', { replace: true })
-              // insert new tracker here
-              // .track('ViewResults')
             }
           }}
           section={currentSection}

--- a/src/components/QuestionsForm/QuestionsForm.tsx
+++ b/src/components/QuestionsForm/QuestionsForm.tsx
@@ -5,7 +5,6 @@ import {
   Navigate
 } from 'react-router-dom'
 import { useTimer } from 'react-timer-hook'
-import { PanelBear } from '../..'
 import {
   DSATimeModifier,
   getNextSection,
@@ -188,7 +187,8 @@ export default function QuestionsForm(props: QuestionsFormProps) {
             } else {
               setView('INFO-end')
               navigate('/results', { replace: true })
-              PanelBear.track('ViewResults')
+              // insert new tracker here
+              // .track('ViewResults')
             }
           }}
           section={currentSection}

--- a/src/components/pages/Privacy.tsx
+++ b/src/components/pages/Privacy.tsx
@@ -20,26 +20,10 @@ function Link({
 export default function Privacy() {
   const { i18n } = useTranslation()
   const components = {
-    trackerLink: <Link href={''} title={''} />, // insert here new tracker data
     localStorage: <Link title="local storage" href={links.localStorageMDN} />
   }
   return (
     <Wrapper title="Privacy & Cookies">
-      {
-        // hidden until tracker is replaced
-        false && (
-          <p>
-            <Trans
-              i18n={i18n}
-              components={{
-                link: components.trackerLink
-              }}
-            >
-              privacy.tracker
-            </Trans>
-          </p>
-        )
-      }
       <p>
         <Trans
           i18n={i18n}

--- a/src/components/pages/Privacy.tsx
+++ b/src/components/pages/Privacy.tsx
@@ -20,26 +20,26 @@ function Link({
 export default function Privacy() {
   const { i18n } = useTranslation()
   const components = {
-    trackerLink: (
-      <Link
-        href={links.privacyPanelbear}
-        title={`"Cookie Free Website Analytics" di PanelBear`}
-      />
-    ),
+    trackerLink: <Link href={''} title={''} />, // insert here new tracker data
     localStorage: <Link title="local storage" href={links.localStorageMDN} />
   }
   return (
     <Wrapper title="Privacy & Cookies">
-      <p>
-        <Trans
-          i18n={i18n}
-          components={{
-            link: components.trackerLink
-          }}
-        >
-          privacy.tracker
-        </Trans>
-      </p>
+      {
+        // hidden until tracker is replaced
+        false && (
+          <p>
+            <Trans
+              i18n={i18n}
+              components={{
+                link: components.trackerLink
+              }}
+            >
+              privacy.tracker
+            </Trans>
+          </p>
+        )
+      }
       <p>
         <Trans
           i18n={i18n}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import * as PanelBear from '@panelbear/panelbear-js'
-export * as PanelBear from '@panelbear/panelbear-js'
-
 import { I18nextProvider } from 'react-i18next'
 import i18n from './i18n'
 
 import App from './components/App'
-
-PanelBear.load('5FyulkL10oK')
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -21,6 +21,6 @@
   },
   "privacy": {
     "tracker": "This website uses a non-invasive tracker to keep track of its performance, complying with GDPR. <br />The website does not store any permanent cookie: transmitted data is anonymized and not traceable to the user. <br />For more info, check out <link />",
-    "localStorage": "It uses the browser <link /> to save user preferences, for example the test mode (regular or DSA) or the website language. These settings are never sent to any server, instead they are handled locally by the browser. Moreover, preferences are deleted after 6 months from the last change."
+    "localStorage": "This website uses the browser <link /> to save user preferences, for example the test mode (regular or DSA) or the website language. These settings are never sent to any server, instead they are handled locally by the browser. Moreover, preferences are deleted after 6 months from the last change."
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -20,7 +20,6 @@
     "main": "<title>The TOL Project</title> by <network>PoliNetwork</network> is licensed under a <cc4>Creative Commons Attribution-ShareAlike 4.0 International License</cc4> <br/> Permissions beyond the scope of this license may be available <githubLicense>here</githubLicense>."
   },
   "privacy": {
-    "tracker": "This website uses a non-invasive tracker to keep track of its performance, complying with GDPR. <br />The website does not store any permanent cookie: transmitted data is anonymized and not traceable to the user. <br />For more info, check out <link />",
     "localStorage": "This website uses the browser <link /> to save user preferences, for example the test mode (regular or DSA) or the website language. These settings are never sent to any server, instead they are handled locally by the browser. Moreover, preferences are deleted after 6 months from the last change."
   }
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -21,6 +21,6 @@
   },
   "privacy": {
     "tracker": "Questo sito utilizza un tracker non invasivo per tener traccia della sua performance, nel rispetto delle norme GDPR. Il sito non salva nessun cookie permanente: ogni dato trasmesso è in forma anonima e non riconducibile all'utente. <br />Per maggiori informazioni, visita la pagina <link />",
-    "localStorage": "Utilizza il <link /> per salvare preferenze e impostazioni utente, utente, come la modalità del test (Regolare o DSA) o la lingua di visualizzazione del sito. Queste impostazioni non vengono mai inviate ad alcun server, ma vengono gestite localmente dal browser. Inoltre, queste vengono eliminate 6 mesi dopo l'ultima modifica."
+    "localStorage": "Questo sito utilizza il <link /> per salvare preferenze e impostazioni utente, utente, come la modalità del test (Regolare o DSA) o la lingua di visualizzazione del sito. Queste impostazioni non vengono mai inviate ad alcun server, ma vengono gestite localmente dal browser. Inoltre, queste vengono eliminate 6 mesi dopo l'ultima modifica."
   }
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -20,7 +20,6 @@
     "main": "<title>The TOL Project</title> by <network>PoliNetwork</network> è rilasciato sotto una licenza <cc4>Creative Commons Attribution-ShareAlike 4.0 International License</cc4>. <br /> Permessi che vanno oltre l'ambito di questa licenza posso essere disponibili <githubLicense>qui</githubLicense>."
   },
   "privacy": {
-    "tracker": "Questo sito utilizza un tracker non invasivo per tener traccia della sua performance, nel rispetto delle norme GDPR. Il sito non salva nessun cookie permanente: ogni dato trasmesso è in forma anonima e non riconducibile all'utente. <br />Per maggiori informazioni, visita la pagina <link />",
     "localStorage": "Questo sito utilizza il <link /> per salvare preferenze e impostazioni utente, utente, come la modalità del test (Regolare o DSA) o la lingua di visualizzazione del sito. Queste impostazioni non vengono mai inviate ad alcun server, ma vengono gestite localmente dal browser. Inoltre, queste vengono eliminate 6 mesi dopo l'ultima modifica."
   }
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,7 +6,6 @@ export const links = {
     'https://github.com/PoliNetworkOrg/TheTOLProject/blob/main/LICENSE',
   githubSource: 'https://github.com/PoliNetworkOrg/TheTOLProject/',
   polinetwork: 'https://polinetwork.org',
-  privacyPanelbear: 'https://panelbear.com/cookie-free-analytics/',
   telegramPreparazioneTOL: 'https://t.me/joinchat/_zugEikozmcyMzA0',
   telegramTheTOLProject: 'https://t.me/+amLdTd-EoHw1MWRk',
   localStorageMDN:


### PR DESCRIPTION
- Locales definitions and strings referring to the tracker weren't removed, but the corresponding text is hidden in the Privacy page until the tracker is replaced and the links changed
- `@panelbear` packages are removed with all the references in the `src`
- Left comments where the previously tracker was used, so that it's easier to replace it

Closes #74