### PR TITLE
fix: show COM track in QPreview

### DIFF
--- a/src/components/Util/Question.tsx
+++ b/src/components/Util/Question.tsx
@@ -50,13 +50,16 @@ export default function Question({
   return (
     <div style={styles.question}>
       <p style={{ margin: 4 }}>
-        {isDebug && <span>{id}</span>}
+        {isDebug && (
+          <p>
+            {id} {valid}
+          </p>
+        )}
         <RenderedText text={q.text} />
         {isTest && <span style={styles.result}>{result}</span>}
       </p>
       {showAttachments && <QuestionAttachments q={q} dbRef={dbRef} />}
 
-      {isDebug && <p>{valid}</p>}
       {Object.entries(q.answers).map(([letter, text]) => {
         const isCorrect = q.correct === letter
         const visibility = isCorrect || choice === letter ? 'visible' : 'hidden'


### PR DESCRIPTION
## Changes
- Only COM questions have sub (afaik), so the dropdown to select the id only show one item per question id
- If question has track (COM ones) it's shown on the right of the questions (or above if on mobile)
- If a question has multiple subs (COM ones), all the questions are listed separated by a line

Closes #80 

## Screenshots
Desktop
![desktop](https://user-images.githubusercontent.com/66379281/233799127-c8eeb387-33fb-468f-9d38-20ab763cf055.png)

Mobile
![mobile](https://user-images.githubusercontent.com/66379281/233799241-0a772223-322d-4823-a613-b9dc115024a8.png)

