### PR TITLE
fix(deps-dev): fix dev ribbon overlap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15985,7 +15985,7 @@
     },
     "node_modules/react-ribbons": {
       "version": "1.0.6",
-      "resolved": "git+ssh://git@github.com/EndBug/react-ribbons.git#3eb618f0042b4557f9fdbb918c388a8e254f9f7f",
+      "resolved": "git+ssh://git@github.com/EndBug/react-ribbons.git#d41095e167baeca2ac9309bd8616c95b8a9b5e68",
       "license": "MIT",
       "peerDependencies": {
         "prop-types": "^15.7.2",
@@ -31227,7 +31227,7 @@
       "version": "0.8.3"
     },
     "react-ribbons": {
-      "version": "git+ssh://git@github.com/EndBug/react-ribbons.git#3eb618f0042b4557f9fdbb918c388a8e254f9f7f",
+      "version": "git+ssh://git@github.com/EndBug/react-ribbons.git#d41095e167baeca2ac9309bd8616c95b8a9b5e68",
       "from": "react-ribbons@github:EndBug/react-ribbons#custom",
       "requires": {}
     },


### PR DESCRIPTION
Closes #79 

Thanks @lorenzocorallo for the dependency fix in https://github.com/EndBug/react-ribbons/pull/9 💖 