### PR TITLE
feat: render question tags (results, q/db-preview)

### DIFF
--- a/src/components/Util/Question.tsx
+++ b/src/components/Util/Question.tsx
@@ -1,8 +1,10 @@
+import { argv0 } from 'process'
 import { DATABASE_REF } from '../../utils/constants'
 import { Question as IQuestion } from '../../utils/database'
 import { StyleSheet } from '../../utils/style'
 import QuestionAttachments from './QuestionAttachments'
 import RenderedText from './RenderedText'
+import { FaAnchor } from 'react-icons/fa'
 
 const styles = StyleSheet.create({
   question: {
@@ -21,6 +23,20 @@ const styles = StyleSheet.create({
   icon: {
     width: '10px',
     height: '10px'
+  },
+  tagsContainer: {
+    borderTop: '1px solid #b1b1b1',
+    borderBottom: '1px solid #b1b1b1',
+    borderColor: 'gray',
+    display: 'flex',
+    alignItems: 'center',
+    marginTop: 16,
+    padding: '12px 0',
+    gap: 8
+  },
+  tags: {
+    margin: 0,
+    fontStyle: 'italic'
   }
 })
 
@@ -35,6 +51,8 @@ interface Props {
   showAttachments?: boolean
   dbRef?: DATABASE_REF
 }
+
+const TEST_TAGS = ['combinazioni e coefficienti binomiali', 'permutazioni']
 
 export default function Question({
   q,
@@ -77,6 +95,23 @@ export default function Question({
           </p>
         )
       })}
+
+      <div style={styles.tagsContainer}>
+        <FaAnchor />
+        <p style={styles.tags}>{concatTags(TEST_TAGS)}</p>
+      </div>
     </div>
   )
+}
+
+function concatTags(tagsArr: string[]): string {
+  return tagsArr
+    .map((tag, i) => {
+      const isFirstTag = i === 0
+      const isLastTag = i === tagsArr.length - 1
+      if (isFirstTag) return `${tag[0].toUpperCase()}${tag.slice(1)}; `
+      if (isLastTag) return `${tag}.`
+      return `${tag}; `
+    })
+    .join('')
 }

--- a/src/components/pages/QPreview.tsx
+++ b/src/components/pages/QPreview.tsx
@@ -31,6 +31,7 @@ export default function QPreview(props: Props) {
         onChange={(v) => setIsCustom(v === 'custom')}
       />
       {isCustom ? <CustomQ /> : <DatabaseQ {...props} />}
+      <br />
     </div>
   )
 }


### PR DESCRIPTION
Implement question tags rendering in results pdf, qpreview and dbpreview pages.
At the moment, the same tags are shown for every question in every section - database/data structure changes needed to conditionally show tags.

This PR is used to achieve the intended rendering style.