### PR TITLE
fix(DBPreview): infinite loading on page refresh

### DIFF
--- a/src/components/pages/DBPreview.tsx
+++ b/src/components/pages/DBPreview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { DATABASE_REF, sectionInfo } from '../../utils/constants'
 import {
   Section,
@@ -22,7 +22,8 @@ interface DBPreviewProps {
 }
 
 export default function DBPreview({ dbs }: DBPreviewProps) {
-  const [db, setDb] = useState(dbs?.stable)
+  const [dbRef, setDbRef] = useState<DATABASE_REF>(DATABASE_REF.STABLE)
+  const db = useMemo(() => dbs?.[dbRef], [dbRef, dbs])
 
   if (!db || !dbs) return <div style={baseStyle}>Loading...</div>
   return (
@@ -34,7 +35,7 @@ export default function DBPreview({ dbs }: DBPreviewProps) {
           { value: DATABASE_REF.MAIN, label: 'Development' }
         ]}
         defaultValue={DATABASE_REF.STABLE}
-        onChange={(v) => setDb(dbs[v as DATABASE_REF])}
+        onChange={(v) => setDbRef(v as DATABASE_REF)}
       />
       {(
         Object.entries(db).filter(([key]) => key != 'meta') as [


### PR DESCRIPTION
## Issue
If `DBPreview` is opened via a direct link or the page is refreshed, the database isn't shown. 

## Fix
Migrate the db selecting/loading logic to that used in `QPreview`  

## Steps to reproduce
1. Open website preview
2. Goto `/#/dbpreview`
3. Refresh the page