### PR TITLE
fix(DBPreview): rendering of images from the development database

### DIFF
--- a/src/components/pages/DBPreview.tsx
+++ b/src/components/pages/DBPreview.tsx
@@ -53,7 +53,12 @@ export default function DBPreview({ dbs }: DBPreviewProps) {
                 .filter((q) => q.text || key == 'com')
                 .map((q) => (
                   <li key={key + q.id + (q.sub || '')}>
-                    <Question q={q} isDebug={true} showAttachments />
+                    <Question
+                      q={q}
+                      isDebug={true}
+                      showAttachments
+                      dbRef={dbRef}
+                    />
                   </li>
                 ))}
             </ul>


### PR DESCRIPTION
The prop `dbRef` was not provided to `<Question />` causing development db images to fail to load.
Now it's correctly provided.

closes #117 