### PR TITLE
fix: replace webp logo with svg

### DIFF
--- a/src/components/ExtendCorrection/DocumentHeader.tsx
+++ b/src/components/ExtendCorrection/DocumentHeader.tsx
@@ -1,5 +1,4 @@
 import { StyleSheet } from '../../utils/style'
-import logo from '../../static/logo3000.webp'
 import { links } from '../../utils/constants'
 
 const styles = StyleSheet.create({
@@ -40,7 +39,7 @@ export default function DocumentHeader() {
         target="_blank"
         href={links.polinetwork}
       >
-        <img src={logo} alt="logo" style={styles.logo} />
+        <img src={links.polinetworkLogoSvg} alt="logo" style={styles.logo} />
         <h1 style={styles.text}>PoliNetwork</h1>
       </a>
       <h1 style={styles.rightText}>The TOL Project</h1>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,6 @@
 import { useContext, useMemo, useState } from 'react'
 import { StyleSheet } from '../utils/style'
 import { statePair } from '../utils/types'
-import logo from '../static/logo3000.webp'
 import { links, View } from '../utils/constants'
 import { MobileContext } from '../utils/contexts'
 import { useTranslation } from 'react-i18next'
@@ -78,7 +77,7 @@ export default function Header({ viewState }: HeaderProps) {
           target="_blank"
           href={links.polinetwork}
         >
-          <img src={logo} alt="logo" style={styles.logo} />
+          <img src={links.polinetworkLogoSvg} alt="logo" style={styles.logo} />
           {!mobile && <h1 style={styles.text}>PoliNetwork</h1>}
         </a>
       </div>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,6 +6,8 @@ export const links = {
     'https://github.com/PoliNetworkOrg/TheTOLProject/blob/main/LICENSE',
   githubSource: 'https://github.com/PoliNetworkOrg/TheTOLProject/',
   polinetwork: 'https://polinetwork.org',
+  polinetworkLogoSvg:
+    'https://raw.githubusercontent.com/PoliNetworkOrg/Logo/1bf5ca6d64658d33d0159c0f526b57a6a31b9fc6/Logo.svg',
   telegramPreparazioneTOL: 'https://t.me/joinchat/_zugEikozmcyMzA0',
   telegramTheTOLProject: 'https://t.me/+amLdTd-EoHw1MWRk',
   localStorageMDN:


### PR DESCRIPTION
The change affects:
- the Header
- the produced PDF

@EndBug @toto04 The review requested regards the approach in loading the svg icon (via href pointing to raw.github)

Closes #101 